### PR TITLE
Add build script to copy Autos to the deploy folder on build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,5 @@ bin/
 *-window.json
 simgui-ds.json
 simgui.json
+
+src/main/deploy/Autos*

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ spotless {
     java {
         target fileTree('.') {
             include '**/*.java'
-            exclude '**/build/**', '**/build-*/**'
+            exclude '**/build/**', '**/build-*/**', '**/deploy/**'
         }
         toggleOffOn()
         googleJavaFormat()
@@ -110,7 +110,7 @@ spotless {
     groovyGradle {
         target fileTree('.') {
             include '**/*.gradle'
-            exclude '**/build/**', '**/build-*/**'
+            exclude '**/build/**', '**/build-*/**', '**/deploy/**'
         }
         greclipse()
         indentWithSpaces(4)
@@ -120,7 +120,7 @@ spotless {
     format 'xml', {
         target fileTree('.') {
             include '**/*.xml'
-            exclude '**/build/**', '**/build-*/**'
+            exclude '**/build/**', '**/build-*/**', '**/deploy/**'
         }
         eclipseWtp('xml')
         trimTrailingWhitespace()
@@ -130,7 +130,7 @@ spotless {
     format 'misc', {
         target fileTree('.') {
             include '**/*.md', '**/.gitignore'
-            exclude '**/build/**', '**/build-*/**'
+            exclude '**/build/**', '**/build-*/**', '**/deploy/**'
         }
         trimTrailingWhitespace()
         indentWithSpaces(2)

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,12 @@ targetCompatibility = JavaVersion.VERSION_11
 
 def ROBOT_MAIN_CLASS = "frc.robot.Main"
 
+tasks.register('copyAutos', Copy) {
+    from "Autos"
+    into "src/main/deploy/Autos"
+}
+tasks.getByName('build').dependsOn(tasks.getByName('copyAutos'))
+
 // Define my targets (RoboRIO) and artifacts (deployable files)
 // This is added by GradleRIO's backing project DeployUtils.
 deploy {


### PR DESCRIPTION
Pathweaver generates Autonomous paths in the Autos folder. In order to parse them, we need them to get copied into the deploy folder. This addition to the build.gradle script will copy them before building/deploying